### PR TITLE
Clarifying exception by Adding URL to message

### DIFF
--- a/lib/indieweb/endpoints/client.rb
+++ b/lib/indieweb/endpoints/client.rb
@@ -4,7 +4,7 @@ module IndieWeb
       def initialize(url)
         @uri = Addressable::URI.parse(url)
 
-        raise ArgumentError, 'url must be an absolute URL (e.g. https://example.com)' unless @uri.absolute? && @uri.scheme.match?(/^https?$/)
+        raise ArgumentError, "url (#{url}) must be an absolute URL (e.g. https://example.com)" unless @uri.absolute? && @uri.scheme.match?(/^https?$/)
       rescue Addressable::URI::InvalidURIError => exception
         raise InvalidURIError, exception
       rescue NoMethodError, TypeError

--- a/spec/lib/indieweb/endpoints/client_spec.rb
+++ b/spec/lib/indieweb/endpoints/client_spec.rb
@@ -15,7 +15,7 @@ describe IndieWeb::Endpoints::Client do
 
   context 'when given a relative URL' do
     it 'raises an ArgumentError' do
-      message = 'url must be an absolute URL (e.g. https://example.com)'
+      message = 'url (../foo/bar/biz/baz) must be an absolute URL (e.g. https://example.com)'
 
       expect { described_class.new('../foo/bar/biz/baz') }.to raise_error(IndieWeb::Endpoints::ArgumentError, message)
     end
@@ -23,7 +23,7 @@ describe IndieWeb::Endpoints::Client do
 
   context 'when given a URL with an invalid protocol' do
     it 'raises an ArgumentError' do
-      message = 'url must be an absolute URL (e.g. https://example.com)'
+      message = 'url (file:///foo/bar/baz) must be an absolute URL (e.g. https://example.com)'
 
       expect { described_class.new('file:///foo/bar/baz') }.to raise_error(IndieWeb::Endpoints::ArgumentError, message)
     end


### PR DESCRIPTION
Prior to this commit, when running a batch of URLs, via [webmention][1],
when I encountered an exception, the entire process halted. It also
halted without insight into which URL was the problem.

With this commit, the exception identifies the bad URL.

Related to indieweb/webmention-client-ruby#23
Related to indieweb/webmention-client-ruby#22

[1]:https://github.com/indieweb/webmention-client-ruby