### PR TITLE
Adding discovery of Pingback end point

### DIFF
--- a/lib/indieweb/endpoints.rb
+++ b/lib/indieweb/endpoints.rb
@@ -23,6 +23,7 @@ require 'indieweb/endpoints/parsers/microsub_parser'
 require 'indieweb/endpoints/parsers/redirect_uri_parser'
 require 'indieweb/endpoints/parsers/token_endpoint_parser'
 require 'indieweb/endpoints/parsers/webmention_parser'
+require 'indieweb/endpoints/parsers/pingback_parser'
 
 module IndieWeb
   module Endpoints

--- a/lib/indieweb/endpoints/parsers/pingback_parser.rb
+++ b/lib/indieweb/endpoints/parsers/pingback_parser.rb
@@ -1,0 +1,22 @@
+module IndieWeb
+  module Endpoints
+    module Parsers
+      class PingbackParser < BaseParser
+        @identifier = :pingback
+
+        Parsers.register(self)
+
+        private
+
+        def results_for_node(node)
+          Services::ResponseBodyParserService.parse(response, self.class.identifier, node)
+        end
+
+        # https://www.w3.org/TR/webmention/#sender-discovers-receiver-webmention-endpoint
+        def results_from_body
+          @results_from_body ||= [results_for_node('link'), results_for_node('a')].flatten.compact
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/indieweb/endpoints/parsers/pingback_parser_spec.rb
+++ b/spec/lib/indieweb/endpoints/parsers/pingback_parser_spec.rb
@@ -1,0 +1,21 @@
+describe IndieWeb::Endpoints::Parsers::PingbackParser do
+  let(:client) { IndieWeb::Endpoints::Client.new(url) }
+
+  context 'when given a URL that does not advertise a Pingback endpoint' do
+    let(:url) { 'https://anyoldurl.com' }
+
+    it 'returns nil' do
+      stub_request(:get, url).to_return(status: 200, headers: { content_type: 'text/html' }, body: '<html lang="en"/>')
+      expect(described_class.new(client.response).results).to eq(nil)
+    end
+  end
+
+  context 'when given a URL advertises a Pingback endpoint' do
+    let(:url) { 'https://anyoldurl.com' }
+
+    it 'returns the discovered Pingback URL' do
+      stub_request(:get, url).to_return(status: 200, headers: { content_type: 'text/html' }, body: %(<html lang="en"><link rel="pingback" href="#{url}/xmlrpc.php"></html>))
+      expect(described_class.new(client.response).results).to eq("#{url}/xmlrpc.php")
+    end
+  end
+end

--- a/spec/lib/indieweb/endpoints_get_spec.rb
+++ b/spec/lib/indieweb/endpoints_get_spec.rb
@@ -12,7 +12,8 @@ describe IndieWeb::Endpoints, :get do
       microsub: nil,
       redirect_uri: nil,
       token_endpoint: nil,
-      webmention: nil
+      webmention: nil,
+      pingback: nil
     )
   end
 


### PR DESCRIPTION
Yes, Pingback is an old technology fraught with issues. But as I've been
working with Webmentions, I'm finding many sights still have Pingback.

As I'm already using this gem to crawl many sites, I'd like to see if
those sites expose a Pingback end-point. My preference is Webmention,
but failing that I'd ping them.