### PR TITLE
Run workflow on pushes to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
Pull Requests are required now to push code to the `main` branch, so we should have some assurance that the code landing there is working. But… a second run against pushes to `main` should be fine. Eventually, if we add automatic publishing of new versions, this will be useful.